### PR TITLE
refactor: DRY audit page layout wrapper

### DIFF
--- a/audit.php
+++ b/audit.php
@@ -24,6 +24,7 @@
 
 chdir('../../');
 include_once('./include/auth.php');
+include_once('./plugins/audit/ui_helpers.php');
 
 set_default_action();
 
@@ -35,9 +36,7 @@ case 'export':
 case 'purge':
 	audit_purge();
 
-	top_header();
-	audit_log();
-	bottom_footer();
+	audit_render_with_layout('audit_log');
 
 	break;
 	case 'getdata':
@@ -132,9 +131,7 @@ case 'purge':
 
 	break;
 default:
-	top_header();
-	audit_log();
-	bottom_footer();
+	audit_render_with_layout('audit_log');
 }
 
 function audit_purge() {
@@ -463,4 +460,3 @@ function audit_log() {
 	<script type='text/javascript' src='plugins/audit/js/functions.js'></script>
 	<?php
 }
-

--- a/tests/test_layout_wrapper.php
+++ b/tests/test_layout_wrapper.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | Regression checks for shared layout wrapper routing in audit.php        |
+ |                                                                         |
+ | Run: php tests/test_layout_wrapper.php                                  |
+ +-------------------------------------------------------------------------+
+ */
+
+$pass = 0;
+$fail = 0;
+$events = array();
+
+function assert_true($label, $value) {
+	global $pass, $fail;
+
+	if ($value) {
+		echo "PASS  $label\n";
+		$pass++;
+	} else {
+		echo "FAIL  $label\n";
+		$fail++;
+	}
+}
+
+function top_header() {
+	global $events;
+	$events[] = 'top_header';
+}
+
+function bottom_footer() {
+	global $events;
+	$events[] = 'bottom_footer';
+}
+
+require_once __DIR__ . '/../ui_helpers.php';
+
+$events = array();
+$runs = 0;
+
+audit_render_with_layout(function () use (&$events, &$runs) {
+	$runs++;
+	$events[] = 'content';
+});
+
+assert_true('layout callback executes once', $runs === 1);
+assert_true('layout call order is top->content->bottom', $events === array('top_header', 'content', 'bottom_footer'));
+
+$source = file_get_contents(__DIR__ . '/../audit.php');
+
+assert_true(
+	'purge/default actions use shared layout helper',
+	substr_count($source, "audit_render_with_layout('audit_log');") >= 2
+);
+assert_true(
+	'audit.php includes ui helper file',
+	strpos($source, "include_once('./plugins/audit/ui_helpers.php');") !== false
+);
+
+echo "\n";
+echo "Results: $pass passed, $fail failed\n";
+
+exit($fail > 0 ? 1 : 0);

--- a/ui_helpers.php
+++ b/ui_helpers.php
@@ -1,0 +1,19 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ */
+
+if (!function_exists('audit_render_with_layout')) {
+	function audit_render_with_layout($renderer) {
+		top_header();
+		call_user_func($renderer);
+		bottom_footer();
+	}
+}


### PR DESCRIPTION
## Summary
- add shared `audit_render_with_layout()` helper for page wrapper rendering
- route wrapped audit action paths through the helper
- preserve behavior while removing duplicated `top_header()/bottom_footer()` wrapper logic

## Tests
- `php -l audit.php`
- `php -l ui_helpers.php`
- `php -l tests/test_layout_wrapper.php`
- `php tests/test_layout_wrapper.php`

Closes #46
